### PR TITLE
Add support for Yaml serialization

### DIFF
--- a/SAGESharp/IO/Attributes.cs
+++ b/SAGESharp/IO/Attributes.cs
@@ -21,13 +21,26 @@ namespace SAGESharp.IO
         public SerializablePropertyAttribute(byte binaryOrder) => BinaryOrder = binaryOrder;
 
         /// <summary>
+        /// Initializes a new attribute to mark a serializable property.
+        /// </summary>
+        /// 
+        /// <param name="binaryOrder">The binary order of property (see <see cref="BinaryOrder"/>).</param>
+        /// <param name="name">The name of the property in text form (see <see cref="Name"/>).</param>
+        public SerializablePropertyAttribute(byte binaryOrder, string name) : this(binaryOrder) => Name = name;
+
+        /// <summary>
         /// The order to serialize/deserialize the property as binary data.
         /// </summary>
         /// 
         /// <remarks>
         /// A single class/struct should not have duplicated values for <see cref="BinaryOrder"/>.
         /// </remarks>
-        public byte BinaryOrder { get; private set; }
+        public byte BinaryOrder { get; }
+
+        /// <summary>
+        /// The name of the property when serialized in text form.
+        /// </summary>
+        public string Name { get; }
     }
 
     /// <summary>

--- a/SAGESharp/IO/Yaml.cs
+++ b/SAGESharp/IO/Yaml.cs
@@ -1,0 +1,52 @@
+﻿/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+using System;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+using Identifier = SAGESharp.SLB.Identifier;
+
+namespace SAGESharp.IO
+{
+    internal sealed class IdentifierYamlTypeConverter : IYamlTypeConverter
+    {
+        public bool Accepts(Type type)
+        {
+            Validate.ArgumentNotNull(nameof(type), type);
+
+            return typeof(Identifier) == type;
+        }
+
+        public object ReadYaml(IParser parser, Type type)
+        {
+            Validate.ArgumentNotNull(nameof(parser), parser);
+            Validate.ArgumentNotNull(nameof(type), type);
+            ValidateType(type);
+
+            string value = parser.Consume<Scalar>().Value;
+
+            return Identifier.From(value);
+        }
+
+        public void WriteYaml(IEmitter emitter, object value, Type type)
+        {
+            Validate.ArgumentNotNull(nameof(emitter), emitter);
+            Validate.ArgumentNotNull(nameof(value), value);
+            Validate.ArgumentNotNull(nameof(type), type);
+            Validate.Argument(value.GetType() == typeof(Identifier),
+                $"The input value is type {value.GetType().Name}, was expecting {typeof(Identifier).Name} instead.");
+            ValidateType(type);
+
+            emitter.Emit(new Scalar(null, value.ToString()));
+        }
+
+        private static void ValidateType(Type type) => Validate.Argument(
+            type == typeof(Identifier),
+            $"Was expecting type {typeof(Identifier).Name} but found {type.Name}"
+        );
+    }
+}

--- a/SAGESharp/IO/Yaml.cs
+++ b/SAGESharp/IO/Yaml.cs
@@ -15,6 +15,36 @@ using Identifier = SAGESharp.SLB.Identifier;
 
 namespace SAGESharp.IO
 {
+    /// <summary>
+    /// Provides serializers to convert to Yaml.
+    /// </summary>
+    public static class YamlSerializer
+    {
+        public static ISerializer BuildSLBSerializer() => new SerializerBuilder()
+                .WithSLBOverrides()
+                .Build();
+    }
+
+    /// <summary>
+    /// Provides serializers to convert from Yaml.
+    /// </summary>
+    public static class YamlDeserializer
+    {
+        public static IDeserializer BuildSLBDeserializer() => new DeserializerBuilder()
+                .WithSLBOverrides()
+                .Build();
+    }
+
+    internal static class BuilderSkeletonExtensions
+    {
+        public static TBuilder WithSLBOverrides<TBuilder>(this TBuilder builderSkeleton) where TBuilder : BuilderSkeleton<TBuilder>
+        {
+            return builderSkeleton
+                .WithTypeConverter(new IdentifierYamlTypeConverter())
+                .WithTypeInspector(inner => new SLBTypeInspector(inner), s => s.InsteadOf<YamlAttributesTypeInspector>());
+        }
+    }
+
     internal sealed class SLBTypeInspector : TypeInspectorSkeleton
     {
         private readonly ITypeInspector typeInspector;

--- a/SAGESharp/SAGESharp.csproj
+++ b/SAGESharp/SAGESharp.csproj
@@ -69,6 +69,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="YamlDotNet, Version=8.0.0.0, Culture=neutral, PublicKeyToken=ec19458f3c15af5e, processorArchitecture=MSIL">
+      <HintPath>..\packages\YamlDotNet.8.0.0\lib\net45\YamlDotNet.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BKD.cs" />

--- a/SAGESharp/SAGESharp.csproj
+++ b/SAGESharp/SAGESharp.csproj
@@ -85,6 +85,7 @@
     <Compile Include="IO\BinarySerializers.cs" />
     <Compile Include="IO\BinaryWriter.cs" />
     <Compile Include="IO\TreeBasedSerialization.cs" />
+    <Compile Include="IO\Yaml.cs" />
     <Compile Include="LSS\Compiler.cs" />
     <Compile Include="LSS\Decompiler.cs" />
     <Compile Include="LSS\Expressions\ArrayAccessExpression.cs" />

--- a/SAGESharp/SLB/Level/Conversation.cs
+++ b/SAGESharp/SLB/Level/Conversation.cs
@@ -12,7 +12,7 @@ namespace SAGESharp.SLB.Level
 {
     public sealed class Conversation : IEquatable<Conversation>
     {
-        [SerializableProperty(1)]
+        [SerializableProperty(1, name: nameof(Conversation))]
         public IList<ConversationCharacter> Entries { get; set; }
 
         public bool Equals(Conversation other)

--- a/SAGESharp/packages.config
+++ b/SAGESharp/packages.config
@@ -3,4 +3,5 @@
   <package id="Konvenience" version="1.0.1" targetFramework="net461" />
   <package id="SharpDX" version="4.2.0" targetFramework="net461" />
   <package id="SharpDX.Mathematics" version="4.2.0" targetFramework="net461" />
+  <package id="YamlDotNet" version="8.0.0" targetFramework="net461" />
 </packages>

--- a/SAGESharpTests/IO/IdentifierYamlTypeConverterTests.cs
+++ b/SAGESharpTests/IO/IdentifierYamlTypeConverterTests.cs
@@ -1,0 +1,162 @@
+﻿/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+using FluentAssertions;
+using NSubstitute;
+using NSubstitute.ClearExtensions;
+using NUnit.Framework;
+using SAGESharp.Testing;
+using System;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+using Identifier = SAGESharp.SLB.Identifier;
+
+namespace SAGESharp.IO
+{
+    class IdentifierYamlTypeConverterTests
+    {
+        private static readonly Type IDENTIFIER_TYPE = typeof(Identifier);
+
+        private readonly IYamlTypeConverter converter = new IdentifierYamlTypeConverter();
+
+        private readonly IEmitter emitter = Substitute.For<IEmitter>();
+
+        private readonly IParser parser = Substitute.For<IParser>();
+
+        [SetUp]
+        public void Setup()
+        {
+            emitter.ClearSubstitute();
+            parser.ClearSubstitute();
+        }
+
+        [Test]
+        public void Test_Should_Accept_Identifier_Type()
+        {
+            bool result = converter.Accepts(IDENTIFIER_TYPE);
+
+            result.Should().BeTrue();
+        }
+
+        [TestCase(typeof(int))]
+        [TestCase(typeof(string))]
+        [TestCase(typeof(IdentifierYamlTypeConverter))]
+        public void Test_Should_Not_Accept_Non_Identifier_Types(Type type)
+        {
+            bool result = converter.Accepts(type);
+
+            result.Should().BeFalse();
+        }
+
+        [Test]
+        public void Test_Reading_A_Valid_Identifier_String()
+        {
+            string value = "TOA1";
+            Identifier identifier = Identifier.From(value);
+            Scalar scalar = new Scalar(value);
+
+            parser.Current.Returns(scalar);
+
+            object result = converter.ReadYaml(parser, IDENTIFIER_TYPE);
+
+            result.Should().Be(identifier);
+        }
+
+        [Test]
+        public void Test_Reading_From_A_Null_Parser()
+        {
+            Action action = () => converter.ReadYaml(null, IDENTIFIER_TYPE);
+
+            action.Should()
+                .ThrowArgumentNullException("parser");
+        }
+
+        [Test]
+        public void Test_Reading_With_A_Null_Type()
+        {
+            Action action = () => converter.ReadYaml(parser, null);
+
+            action.Should()
+                .ThrowArgumentNullException("type");
+        }
+
+        [Test]
+        public void Test_Reading_With_An_Invalid_Type()
+        {
+            Type type = typeof(string);
+            Action action = () => converter.ReadYaml(parser, type);
+
+            action.Should()
+                .ThrowExactly<ArgumentException>()
+                .WithMessage($"Was expecting type {IDENTIFIER_TYPE.Name} but found {type.Name}");
+        }
+
+        [Test]
+        public void Test_Writing_A_Valid_Identifier()
+        {
+            string identifier = "TOA2";
+
+            converter.WriteYaml(emitter, Identifier.From(identifier), IDENTIFIER_TYPE);
+
+            emitter.Received().Emit(Arg.Do<Scalar>(scalar =>
+            {
+                scalar.Tag.Should().BeNull();
+
+                scalar.Value.Should().Be(identifier);
+            }));
+        }
+
+        [Test]
+        public void Test_Writing_To_A_Null_Emitter()
+        {
+            Action action = () => converter.WriteYaml(null, Identifier.ZERO, IDENTIFIER_TYPE);
+
+            action.Should()
+                .ThrowArgumentNullException("emitter");
+        }
+
+        [Test]
+        public void Test_Writing_A_Null_Identifier()
+        {
+            Action action = () => converter.WriteYaml(emitter, null, IDENTIFIER_TYPE);
+
+            action.Should()
+                .ThrowArgumentNullException("value");
+        }
+
+        [Test]
+        public void Test_Writing_With_A_Null_Type()
+        {
+            Action action = () => converter.WriteYaml(emitter, Identifier.ZERO, null);
+
+            action.Should()
+                .ThrowArgumentNullException("type");
+        }
+
+        [Test]
+        public void Test_Writing_With_An_Invalid_Type()
+        {
+            Type type = typeof(string);
+            Action action = () => converter.WriteYaml(emitter, Identifier.ZERO, type);
+
+            action.Should()
+                .ThrowExactly<ArgumentException>()
+                .WithMessage($"Was expecting type {IDENTIFIER_TYPE.Name} but found {type.Name}");
+        }
+
+        [Test]
+        public void Test_Writing_A_Non_Identifier_Value()
+        {
+            string value = string.Empty;
+            Action action = () => converter.WriteYaml(emitter, value, IDENTIFIER_TYPE);
+
+            action.Should()
+                .ThrowExactly<ArgumentException>()
+                .WithMessage($"The input value is type {value.GetType().Name}, was expecting {IDENTIFIER_TYPE.Name} instead.");
+        }
+    }
+}

--- a/SAGESharpTests/IO/SLBTypeInspectorTests.cs
+++ b/SAGESharpTests/IO/SLBTypeInspectorTests.cs
@@ -1,0 +1,96 @@
+﻿/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+using FluentAssertions;
+using Konvenience;
+using NSubstitute;
+using NSubstitute.ClearExtensions;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using YamlDotNet.Serialization;
+
+namespace SAGESharp.IO
+{
+    class SLBTypeInspectorTests
+    {
+        private readonly ITypeInspector innerTypeInspector;
+
+        private readonly ITypeInspector typeInspector;
+
+        public SLBTypeInspectorTests()
+        {
+            innerTypeInspector = Substitute.For<ITypeInspector>();
+            typeInspector = new SLBTypeInspector(innerTypeInspector);
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            innerTypeInspector.ClearSubstitute();
+        }
+
+        [Test]
+        public void Test_GetProperties_With_A_Type_That_Has_SerializablePropertyAttribute()
+        {
+            Type type = typeof(string);
+            string container = string.Empty;
+            IReadOnlyList<IPropertyDescriptor> expectedPropertyDescriptors = new List<IPropertyDescriptor>
+            {
+                DescriptorWithSerializablePropertyAttribute(new SerializablePropertyAttribute(0)),
+                DescriptorWithSerializablePropertyAttribute(new SerializablePropertyAttribute(1, "Property")),
+            };
+            IEnumerable<IPropertyDescriptor> input = expectedPropertyDescriptors.Concat(new List<IPropertyDescriptor>
+            {
+                Substitute.For<IPropertyDescriptor>()
+            });
+
+            innerTypeInspector.GetProperties(type, container).Returns(input);
+
+            var result = typeInspector.GetProperties(type, container);
+
+            innerTypeInspector.Received().GetProperties(type, container);
+
+            result.Should().NotBeNull().And.HaveCount(expectedPropertyDescriptors.Count);
+
+            result.ForEach((propertyDescriptor, index) =>
+            {
+                var expectedPropertyDescriptor = expectedPropertyDescriptors[index];
+
+                expectedPropertyDescriptor.Name.Should().Be(expectedPropertyDescriptor.Name);
+                expectedPropertyDescriptor.Order.Should().Be(expectedPropertyDescriptor.Order);
+            });
+        }
+
+        [Test]
+        public void Test_GetProperties_With_No_SerializablePropertyAttribute()
+        {
+            Type type = typeof(string);
+            string container = string.Empty;
+
+            innerTypeInspector.GetProperties(type, container).Returns(new List<IPropertyDescriptor>
+            {
+                Substitute.For<IPropertyDescriptor>(),
+                Substitute.For<IPropertyDescriptor>()
+            });
+
+            var result = typeInspector.GetProperties(type, container);
+
+            innerTypeInspector.Received().GetProperties(type, container);
+
+            result.Should().NotBeNull().And.BeEmpty();
+        }
+
+        private static IPropertyDescriptor DescriptorWithSerializablePropertyAttribute(SerializablePropertyAttribute attribute)
+        {
+            IPropertyDescriptor result = Substitute.For<IPropertyDescriptor>();
+
+            result.GetCustomAttribute<SerializablePropertyAttribute>().Returns(attribute);
+
+            return result;
+        }
+    }
+}

--- a/SAGESharpTests/SAGESharpTests.csproj
+++ b/SAGESharpTests/SAGESharpTests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="IO\OffsetNodeTests.cs" />
     <Compile Include="IO\PaddingNodeTests.cs" />
     <Compile Include="IO\PrimitiveTypeDataNodeTests.cs" />
+    <Compile Include="IO\SLBTypeInspectorTests.cs" />
     <Compile Include="IO\StringDataNodeTests.cs" />
     <Compile Include="IO\Substitutes.cs" />
     <Compile Include="IO\TreeBinarySerializerTests.cs" />

--- a/SAGESharpTests/SAGESharpTests.csproj
+++ b/SAGESharpTests/SAGESharpTests.csproj
@@ -143,10 +143,19 @@
     <None Include="Test Data\SLB\Level\Conversation\ComplexConversation.slb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Test Data\SLB\Level\Conversation\ComplexConversation.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Test Data\SLB\Level\Conversation\EmptyConversation.slb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Test Data\SLB\Level\Conversation\EmptyConversation.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Test Data\SLB\Level\Conversation\SimpleConversation.slb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Test Data\SLB\Level\Conversation\SimpleConversation.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/SAGESharpTests/SAGESharpTests.csproj
+++ b/SAGESharpTests/SAGESharpTests.csproj
@@ -69,6 +69,9 @@
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="YamlDotNet, Version=8.0.0.0, Culture=neutral, PublicKeyToken=ec19458f3c15af5e, processorArchitecture=MSIL">
+      <HintPath>..\packages\YamlDotNet.8.0.0\lib\net45\YamlDotNet.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BKDEqualityTests.cs" />

--- a/SAGESharpTests/SAGESharpTests.csproj
+++ b/SAGESharpTests/SAGESharpTests.csproj
@@ -85,6 +85,7 @@
     <Compile Include="IO\BinaryWriterTests.cs" />
     <Compile Include="IO\BinaryWriterWrapperTests.cs" />
     <Compile Include="IO\EdgeTests.cs" />
+    <Compile Include="IO\IdentifierYamlTypeConverterTests.cs" />
     <Compile Include="IO\ListNodeTests.cs" />
     <Compile Include="IO\OffsetNodeTests.cs" />
     <Compile Include="IO\PaddingNodeTests.cs" />

--- a/SAGESharpTests/SLB/Level/SerializationTests.cs
+++ b/SAGESharpTests/SLB/Level/SerializationTests.cs
@@ -18,7 +18,7 @@ namespace SAGESharp.SLB.Level
         {
             var serializer = BinarySerializer.ForType<Conversation>();
 
-            using (var stream = new FileStream(testCaseData.TestFilePath, FileMode.Open))
+            using (var stream = new FileStream(testCaseData.SLBFilePath, FileMode.Open))
             {
                 var reader = Reader.ForStream(stream);
 
@@ -33,7 +33,7 @@ namespace SAGESharp.SLB.Level
         public void Test_Writing_A_Conversation_To_A_File_Successfully(SerializationTestCaseData<Conversation> testCaseData)
         {
             var serializer = BinarySerializer.ForType<Conversation>();
-            var outputFilePath = $"{testCaseData.TestFilePath}.tst";
+            var outputFilePath = $"{testCaseData.SLBFilePath}.tst";
 
             using (var stream = new FileStream(outputFilePath, FileMode.Create))
             {
@@ -43,7 +43,7 @@ namespace SAGESharp.SLB.Level
             }
 
             var actual = File.ReadAllBytes(outputFilePath);
-            var expected = File.ReadAllBytes(testCaseData.TestFilePath);
+            var expected = File.ReadAllBytes(testCaseData.SLBFilePath);
             
             actual.Should().Equal(expected);
         }
@@ -52,17 +52,17 @@ namespace SAGESharp.SLB.Level
         {
             new SerializationTestCaseData<Conversation>(
                 description: "Test serializing with an empty file",
-                testFilePath: PathForTestFile("EmptyConversation.slb"),
+                testFilePath: PathForTestFile("EmptyConversation"),
                 expectedProvider: TestData.EmptyConversation
             ),
             new SerializationTestCaseData<Conversation>(
                 description: "Test serializing a file with a simple conversation",
-                testFilePath: PathForTestFile("SimpleConversation.slb"),
+                testFilePath: PathForTestFile("SimpleConversation"),
                 expectedProvider: TestData.SimpleConversation
             ),
             new SerializationTestCaseData<Conversation>(
                 description: "Test serializing a file with a complex conversation",
-                testFilePath: PathForTestFile("ComplexConversation.slb"),
+                testFilePath: PathForTestFile("ComplexConversation"),
                 expectedProvider: TestData.ComplexConversation
             )
         };

--- a/SAGESharpTests/SLB/Level/SerializationTests.cs
+++ b/SAGESharpTests/SLB/Level/SerializationTests.cs
@@ -8,13 +8,15 @@ using NUnit.Framework;
 using SAGESharp.IO;
 using SAGESharp.Testing;
 using System.IO;
+using YamlDotNet.Serialization;
 
 namespace SAGESharp.SLB.Level
 {
     class SerializationTests
     {
+        #region Binary SLB
         [TestCaseSource(nameof(TEST_CASES))]
-        public void Test_Reading_A_Conversation_File_Successfully(SerializationTestCaseData<Conversation> testCaseData)
+        public void Test_Reading_A_Binary_Conversation_File_Successfully(SerializationTestCaseData<Conversation> testCaseData)
         {
             var serializer = BinarySerializer.ForType<Conversation>();
 
@@ -30,7 +32,7 @@ namespace SAGESharp.SLB.Level
         }
 
         [TestCaseSource(nameof(TEST_CASES))]
-        public void Test_Writing_A_Conversation_To_A_File_Successfully(SerializationTestCaseData<Conversation> testCaseData)
+        public void Test_Writing_A_Conversation_To_A_Binary_File_Successfully(SerializationTestCaseData<Conversation> testCaseData)
         {
             var serializer = BinarySerializer.ForType<Conversation>();
             var outputFilePath = $"{testCaseData.SLBFilePath}.tst";
@@ -47,6 +49,31 @@ namespace SAGESharp.SLB.Level
             
             actual.Should().Equal(expected);
         }
+        #endregion
+
+        #region Yaml
+        [TestCaseSource(nameof(TEST_CASES))]
+        public void Test_Reading_A_Yaml_Conversation_File_Successfully(SerializationTestCaseData<Conversation> testCaseData)
+        {
+            IDeserializer deserializer = YamlDeserializer.BuildSLBDeserializer();
+            string fileContent = File.ReadAllText(testCaseData.YamlFilePath);
+
+            Conversation result = deserializer.Deserialize<Conversation>(fileContent);
+
+            result.Should().Be(testCaseData.Expected);
+        }
+
+        [TestCaseSource(nameof(TEST_CASES))]
+        public void Test_Writing_A_Yaml_Conversation_File_Successfully(SerializationTestCaseData<Conversation> testCaseData)
+        {
+            ISerializer serializer = YamlSerializer.BuildSLBSerializer();
+
+            string result = serializer.Serialize(testCaseData.Expected);
+            string expectedFile = File.ReadAllText(testCaseData.YamlFilePath);
+
+            result.Should().Be(expectedFile);
+        }
+        #endregion
 
         static object[] TEST_CASES() => new object[]
         {

--- a/SAGESharpTests/Test Data/SLB/Level/Conversation/ComplexConversation.yaml
+++ b/SAGESharpTests/Test Data/SLB/Level/Conversation/ComplexConversation.yaml
@@ -1,0 +1,115 @@
+Conversation:
+- ToaName: TOA1
+  CharName: NAM1
+  CharCont: CON1
+  Entries:
+  - LineSide: Right
+    ConditionStart: 16843009
+    ConditionEnd: 33686018
+    StringLabel: LAB1
+    StringIndex: 336794129
+    Frames:
+    - ToaAnimation: 257
+      CharAnimation: 258
+      CameraPositionTarget: 259
+      CameraDistance: 260
+      StringIndex: 261
+      ConversationSounds: SOUNDS1
+  - LineSide: Left
+    ConditionStart: 67372036
+    ConditionEnd: 134744072
+    StringLabel: LAB2
+    StringIndex: 606282273
+    Frames:
+    - ToaAnimation: 513
+      CharAnimation: 514
+      CameraPositionTarget: 515
+      CameraDistance: 516
+      StringIndex: 517
+      ConversationSounds: SOUNDS2
+    - ToaAnimation: 769
+      CharAnimation: 770
+      CameraPositionTarget: 771
+      CameraDistance: 772
+      StringIndex: 773
+      ConversationSounds: SOUNDS3
+  - LineSide: Right
+    ConditionStart: 269488144
+    ConditionEnd: 538976288
+    StringLabel: LAB3
+    StringIndex: 875770417
+    Frames:
+    - ToaAnimation: 1025
+      CharAnimation: 1026
+      CameraPositionTarget: 1027
+      CameraDistance: 1028
+      StringIndex: 1029
+      ConversationSounds: SOUNDS4
+    - ToaAnimation: 1281
+      CharAnimation: 1282
+      CameraPositionTarget: 1283
+      CameraDistance: 1284
+      StringIndex: 1285
+      ConversationSounds: SOUNDS5
+    - ToaAnimation: 1537
+      CharAnimation: 1538
+      CameraPositionTarget: 1539
+      CameraDistance: 1540
+      StringIndex: 1541
+      ConversationSounds: SOUNDS6
+- ToaName: TOA2
+  CharName: NAM2
+  CharCont: CON2
+  Entries:
+  - LineSide: Left
+    ConditionStart: 1077952576
+    ConditionEnd: 2155905152
+    StringLabel: LAB4
+    StringIndex: 1145258561
+    Frames:
+    - ToaAnimation: 1793
+      CharAnimation: 1794
+      CameraPositionTarget: 1795
+      CameraDistance: 1796
+      StringIndex: 1797
+      ConversationSounds: SOUNDS7
+  - LineSide: Right
+    ConditionStart: 286331153
+    ConditionEnd: 572662306
+    StringLabel: LAB5
+    StringIndex: 1414746705
+    Frames:
+    - ToaAnimation: 2049
+      CharAnimation: 2050
+      CameraPositionTarget: 2051
+      CameraDistance: 2052
+      StringIndex: 2053
+      ConversationSounds: SOUNDS8
+- ToaName: TOA3
+  CharName: NAM3
+  CharCont: CON3
+  Entries:
+  - LineSide: Left
+    ConditionStart: 1145324612
+    ConditionEnd: 2290649224
+    StringLabel: LAB6
+    StringIndex: 1684234849
+    Frames:
+    - ToaAnimation: 2305
+      CharAnimation: 2306
+      CameraPositionTarget: 2307
+      CameraDistance: 2308
+      StringIndex: 2309
+      ConversationSounds: SOUNDS9
+    - ToaAnimation: 2561
+      CharAnimation: 2562
+      CameraPositionTarget: 2563
+      CameraDistance: 2564
+      StringIndex: 2565
+      ConversationSounds: SOUNDSA
+    - ToaAnimation: 2817
+      CharAnimation: 2818
+      CameraPositionTarget: 2819
+      CameraDistance: 2820
+      StringIndex: 2821
+      ConversationSounds: SOUNDSB

--- a/SAGESharpTests/Test Data/SLB/Level/Conversation/EmptyConversation.yaml
+++ b/SAGESharpTests/Test Data/SLB/Level/Conversation/EmptyConversation.yaml
@@ -1,0 +1,1 @@
+﻿Conversation: []

--- a/SAGESharpTests/Test Data/SLB/Level/Conversation/SimpleConversation.yaml
+++ b/SAGESharpTests/Test Data/SLB/Level/Conversation/SimpleConversation.yaml
@@ -1,0 +1,17 @@
+﻿Conversation:
+- ToaName: TOA1
+  CharName: NAME
+  CharCont: CONT
+  Entries:
+  - LineSide: Right
+    ConditionStart: 2172748161
+    ConditionEnd: 2122219134
+    StringLabel: STRX
+    StringIndex: 1122334455
+    Frames:
+    - ToaAnimation: 1
+      CharAnimation: 2
+      CameraPositionTarget: 1431655765
+      CameraDistance: 4
+      StringIndex: 5
+      ConversationSounds: SOUND

--- a/SAGESharpTests/Testing/SerializationTestCaseData.cs
+++ b/SAGESharpTests/Testing/SerializationTestCaseData.cs
@@ -37,6 +37,11 @@ namespace SAGESharp.Testing
         public string TestFilePath { get; }
 
         /// <summary>
+        /// The <see cref="TestFilePath"/> with the SLB extension appended at the end.
+        /// </summary>
+        public string SLBFilePath { get => $"{TestFilePath}.slb"; }
+
+        /// <summary>
         /// The object that is expected to be read or write in the test.
         /// </summary>
         public T Expected { get => expectedProvider(); }

--- a/SAGESharpTests/Testing/SerializationTestCaseData.cs
+++ b/SAGESharpTests/Testing/SerializationTestCaseData.cs
@@ -42,6 +42,11 @@ namespace SAGESharp.Testing
         public string SLBFilePath { get => $"{TestFilePath}.slb"; }
 
         /// <summary>
+        /// The <see cref="TestFilePath"/> with the Yaml extension appended at the end.
+        /// </summary>
+        public string YamlFilePath { get => $"{TestFilePath}.yaml"; }
+
+        /// <summary>
         /// The object that is expected to be read or write in the test.
         /// </summary>
         public T Expected { get => expectedProvider(); }

--- a/SAGESharpTests/packages.config
+++ b/SAGESharpTests/packages.config
@@ -17,4 +17,5 @@
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net461" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
+  <package id="YamlDotNet" version="8.0.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This change adds support to serializing/deserializing SLB files using the existing code and the [YamlDotNet](https://github.com/aaubry/YamlDotNet) library.

There are plenty of things to do (like smarter `Identifier` parsing) but this will do for now.